### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ After that, add the Pushinator MCP to your MCP client (the API token can be retr
     }
 }
 ```
+
+<a href="https://glama.ai/mcp/servers/@appricos/pushinator-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@appricos/pushinator-mcp/badge" alt="mcp-pushinator MCP server" />
+</a>


### PR DESCRIPTION
This PR adds a badge for the [mcp-pushinator](https://glama.ai/mcp/servers/@appricos/pushinator-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@appricos/pushinator-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@appricos/pushinator-mcp/badge" alt="mcp-pushinator MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.